### PR TITLE
Enable integrity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,12 @@
       <groupId>org.archive.access-control</groupId>
       <artifactId>access-control</artifactId>
       <version>0.1.0-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.netpreserve.commons</groupId>
+          <artifactId>webarchive-commons</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.pig</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.commoncrawl</groupId>
       <artifactId>ia-web-commons</artifactId>
-      <version>1.1.9-SNAPSHOT</version>
+      <version>1.1.10-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.1.3</version>
+      <version>4.5.10</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>
@@ -78,12 +78,12 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.5</version>
+      <version>1.7.28</version>
     </dependency>
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>3.1</version>
+      <version>3.2.2</version>
       <scope>compile</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.archive</groupId>
+      <groupId>org.commoncrawl</groupId>
       <artifactId>ia-web-commons</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>1.1.8-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
     <repository>
       <id>internetarchive</id>
       <name>Internet Archive Maven Repository</name>
-      <url>http://builds.archive.org:8080/maven2</url>
+      <url>http://builds.archive.org/maven2</url>
       <layout>default</layout>
 
       <releases>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.commoncrawl</groupId>
       <artifactId>ia-web-commons</artifactId>
-      <version>1.1.8-SNAPSHOT</version>
+      <version>1.1.9-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <packaging>jar</packaging>
 
   <name>ia-hadoop-tools</name>
-  <url>http://maven.apache.org</url>
+  <url>https://github.com/commoncrawl/ia-hadoop-tools</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/org/archive/hadoop/jobs/WEATGenerator.java
+++ b/src/main/java/org/archive/hadoop/jobs/WEATGenerator.java
@@ -66,6 +66,7 @@ public class WEATGenerator extends Configured implements Tool {
 
       try {
         Logger.getLogger("org.archive.format.gzip.GZIPMemberSeries").setLevel(Level.WARNING);
+        Logger.getLogger("org.archive.extract.ExtractingResourceProducer").setLevel(Level.WARNING);
 
         Path inputPath = new Path(path);
         Path basePath = inputPath.getParent().getParent();

--- a/src/main/java/org/archive/hadoop/jobs/WEATGenerator.java
+++ b/src/main/java/org/archive/hadoop/jobs/WEATGenerator.java
@@ -54,6 +54,9 @@ public class WEATGenerator extends Configured implements Tool {
 
   public static final Log LOG = LogFactory.getLog(WEATGenerator.class);
 
+  // TODO: modify this class to also output cdx files. Look at hadoop plugins for fetch and/or other classes in this project for hints.
+  // TODO: new property for cdx paths or something is likely needed, same as fetch...
+  
   public static class WEATGeneratorMapper extends MapReduceBase implements Mapper<Text, Text, Text, Text> {
     private JobConf jobConf;
 

--- a/src/main/java/org/archive/hadoop/jobs/WEATGenerator.java
+++ b/src/main/java/org/archive/hadoop/jobs/WEATGenerator.java
@@ -271,7 +271,12 @@ public class WEATGenerator extends Configured implements Tool {
     boolean atLeastOneInput = false;
     for (int i = arg;i < args.length; i++) {
       FileSystem inputfs = FileSystem.get( new java.net.URI( args[i] ), getConf() );
-      for ( FileStatus status : inputfs.globStatus( new Path( args[i] ) ) ) {
+      FileStatus[] inputPaths = inputfs.globStatus( new Path( args[i] ) );
+      if (inputPaths == null) {
+        LOG.warn("No input found for: " + args[i]);
+        continue;
+      }
+      for ( FileStatus status : inputPaths ) {
         Path inputPath  = status.getPath();
         atLeastOneInput = true;
         LOG.info( "Add input path: " + inputPath );

--- a/src/main/java/org/archive/hadoop/mapreduce/ZipNumPartitioner.java
+++ b/src/main/java/org/archive/hadoop/mapreduce/ZipNumPartitioner.java
@@ -15,9 +15,9 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.Partitioner;
 import org.archive.util.binsearch.SortedTextFile;
 import org.archive.util.iterator.CloseableIterator;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONTokener;
+import com.github.openjson.JSONArray;
+import com.github.openjson.JSONException;
+import com.github.openjson.JSONTokener;
 
 public class ZipNumPartitioner<K, V> extends Partitioner<K, V> implements Configurable {
 	

--- a/src/main/java/org/archive/hadoop/pig/ZipNumRecordReader.java
+++ b/src/main/java/org/archive/hadoop/pig/ZipNumRecordReader.java
@@ -32,7 +32,7 @@ public class ZipNumRecordReader extends RecordReader<Text, Text> {
 	}
 
 	@Override
-	public float getProgress() {
+	public float getProgress() throws IOException {
 		return inner.getProgress();
 	}
 

--- a/src/main/java/org/archive/hadoop/streaming/ZipNumRecordReader.java
+++ b/src/main/java/org/archive/hadoop/streaming/ZipNumRecordReader.java
@@ -66,7 +66,7 @@ public class ZipNumRecordReader implements RecordReader<Text, Text> {
 	
 
 	@Override
-	public float getProgress() {
+	public float getProgress() throws IOException {
 		return inner.getProgress();
 	}
 

--- a/src/main/java/org/archive/server/FileBackedInputStream.java
+++ b/src/main/java/org/archive/server/FileBackedInputStream.java
@@ -22,8 +22,9 @@ public class FileBackedInputStream extends FilterInputStream {
 	public boolean markSupported() {
 		return false;
 	}
+
 	public InputStream getInputStream() throws IOException {
-		return backer.getSupplier().getInput();
+		return backer.asByteSource().openStream();
 	}
 
 	public void resetBacker() throws IOException {

--- a/src/main/java/org/archive/server/GZRangeClient.java
+++ b/src/main/java/org/archive/server/GZRangeClient.java
@@ -30,7 +30,6 @@ import org.archive.util.IAUtils;
 import org.archive.util.DateUtils;
 import org.archive.util.FileNameSpec;
 import com.google.common.io.ByteStreams;
-import com.google.common.io.LimitInputStream;
 
 public class GZRangeClient {
 
@@ -284,7 +283,7 @@ http-header-from: archive-crawler-agent@lists.sourceforge.net
 		if(currentWarcSize == 0) {
 			nextWarc();
 		}
-		LimitInputStream lis = new LimitInputStream(is, length);
+		InputStream lis = ByteStreams.limit(is, length);
 		ByteStreams.copy(lis, currentWarcOS);
 		currentWarcSize += length;
 		if(currentWarcSize > maxWarcSize) {
@@ -295,7 +294,7 @@ http-header-from: archive-crawler-agent@lists.sourceforge.net
 		if(currentArcSize == 0) {
 			nextArc();
 		}
-		LimitInputStream lis = new LimitInputStream(is, length);
+		InputStream lis = ByteStreams.limit(is, length);
 		ByteStreams.copy(lis, currentArcOS);
 		currentArcSize += length;
 		if(currentArcSize > maxArcSize) {

--- a/src/main/java/org/archive/server/GZRangeServer.java
+++ b/src/main/java/org/archive/server/GZRangeServer.java
@@ -24,7 +24,6 @@ import org.mortbay.jetty.Server;
 import org.mortbay.jetty.handler.AbstractHandler;
 
 import com.google.common.io.ByteStreams;
-import com.google.common.io.LimitInputStream;
 
 public class GZRangeServer extends AbstractHandler implements Tool {
 	public final static String TOOL_NAME = "gzrange-server";
@@ -161,8 +160,7 @@ public class GZRangeServer extends AbstractHandler implements Tool {
 							response.setContentType("application/octet-stream");
 							response.setStatus(HttpServletResponse.SC_PARTIAL_CONTENT);
 							response.setContentLength((int)gzLength);
-							LimitInputStream lis = 
-								new LimitInputStream(fis, gzLength);
+							InputStream lis = ByteStreams.limit(fis, length);
 							long copied = ByteStreams.copy(lis,
 									response.getOutputStream());
 							if(copied != gzLength) {


### PR DESCRIPTION
The intention of this PR is to enable integrity file output.
This will involve:

1. outputting cdx files for wet/wat files as well.
2. running the spark job to output integrity files (folder of text files)

I've started by laying out TODO's in the places where I think we will need to make changes.

This will need to coordinate with a PR in crawl-tools as well. I will put the link to it here shortly.